### PR TITLE
feat: PHP 8.2 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
+          - '8.2'
           - '8.3'
           - '8.4'
     name: "Unit tests (PHP ${{ matrix.php }})"

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-        "php": "8.3.*|8.4.*",
+        "php": ">=8.2",
         "symfony/framework-bundle": "6.4.*|^7.0",
         "symfony/event-dispatcher": "6.4.*|^7.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "^12.3",
+      "phpunit/phpunit": "^11.5|^12.3",
       "phpstan/phpstan": "^2.1",
       "friendsofphp/php-cs-fixer": "^3.86",
       "symfony/polyfill-mbstring": "^1.32",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 10
+    phpVersion: 80200  # Check against PHP 8.2 compatibility.
     paths:
         - src
         - tests

--- a/src/LlmDetection.php
+++ b/src/LlmDetection.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 final class LlmDetection implements LlmDetectionInterface
 {
     // Source: https://momenticmarketing.com/blog/ai-search-crawlers-bots
-    public const array CRAWLER_USER_AGENTS = [
+    public const CRAWLER_USER_AGENTS = [
         [LlmCrawler::OPEN_AI, ['GPTBot', 'ChatGPT-User', 'OAI-SearchBot']],
         [LlmCrawler::ANTHROPIC, ['anthropic-ai', 'ClaudeBot', 'claude-web']],
         [LlmCrawler::PERPLEXITY, ['PerplexityBot', 'Perplexity-User']],


### PR DESCRIPTION
PHP 8.2 is still maintained for one year and supported by Symfony 7, so no reason to not make the bundle compatible with this version.